### PR TITLE
Updates

### DIFF
--- a/circleci/workflows_lib.py
+++ b/circleci/workflows_lib.py
@@ -409,6 +409,8 @@ class Fetch(CircleCiCommand):
                 )
                 if self.args.fetch_workflow_details:
                     Log(f"Fetching {len(runs)} workflow run details for '{workflow}'.")
+                if not runs:
+                    continue
                 run_count += len(runs)
                 for run_index, run in enumerate(runs, 1):
                     run["workflow"] = workflow

--- a/circleci/workflows_lib_test.py
+++ b/circleci/workflows_lib_test.py
@@ -37,9 +37,10 @@ class WorkflowsTest(unittest.TestCase):
             set(Command._commands.keys()).issuperset(
                 {
                     "combine",
-                    "fetch_details",
                     "fetch",
+                    "fetch_details",
                     "filter",
+                    "help",
                     "request_branches",
                     "request_workflow",
                     "request_workflows",
@@ -47,15 +48,15 @@ class WorkflowsTest(unittest.TestCase):
             )
         )
 
-    def test_Workflows(self):
+    def test_RequestBranches(self):
         """Lower level mocking to prove the pieces work together.
 
         Here we bypass the CircleCiApiV2 almost completey as we mock the highest level function we
         call there. That function `RequestBranches` will be mocked, by injection, through mocking
         the `CircleCiCommand._InitCircleCiClient`.
 
-        Now we can call the `branches` sub-command normally by providing an appropriate argv to
-        `Command.Run`. The mocked return_value for the `RequestBranches` will be our result.
+        Now we can call the `request_branches` sub-command normally by providing an appropriate argv
+        to `Command.Run`. The mocked return_value for the `RequestBranches` will be our result.
         """
         with open(os.devnull, "w") as err:
             with redirect_stderr(err):

--- a/mbo/app/flags_test.py
+++ b/mbo/app/flags_test.py
@@ -201,6 +201,7 @@ class FlagsTest(unittest.TestCase):
                 self.assertEqual(
                     test.expected, args.flag, "Bad value in test: " + test.test
                 )
+                self.assertIsInstance(args.flag, type(test.expected))
             except argparse.ArgumentError as error:
                 self.assertIsNotNone(test.expected_error, error)
                 if test.expected_error:
@@ -448,6 +449,17 @@ class FlagsTest(unittest.TestCase):
                 action=ActionArgs(
                     action=mbo.app.flags.ActionDateTimeOrTimeDelta,
                     nargs="?",
+                    verify_only=True,
+                ),
+                input=[],
+            ),
+            FlagTestData(
+                test="Non present flag with default.",
+                expected=str(_NOW_DATETIME),
+                expected_error=argparse.ArgumentError,
+                action=ActionArgs(
+                    "--flag",
+                    action=mbo.app.flags.ActionDateTimeOrTimeDelta,
                     verify_only=True,
                 ),
                 input=[],


### PR DESCRIPTION
Updates
* Do not log the `fetching` log lines for a workflow with 0 runs. The result would be logging the last non-zero count.
* The current only workflows_lib test actually tests request_branches not workflows.
* Fix an issue with datetime parsing when verify_only is active. Also add a test.